### PR TITLE
Updated docs with working examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ In your project's Gruntfile, add a section named `pdepend` to the data object pa
 ```js
 grunt.initConfig({
   pdepend: {
-    options: {
-      // Task-specific options go here.
-    },
-    dir: {
-      // Target-specific file lists and/or options go here.
-    },
-  },
+    default: {
+      dir: [
+        // Task-specific options go here.
+      ],
+      options: {
+        // Task-specific options go here.
+      }
+    }
+  }
 });
 ```
 
@@ -133,22 +135,24 @@ Prints pdepend debugging information.
 ```js
 grunt.initConfig({
     pdepend: {
-        dir: [
-            'php'
-        ],
-        options: {
-            bin: 'vendor/bin/pdepend',
-            jdependChart: 'jdependChart.svg',
-            jdependXml: 'jdependXml.xml',
-            overviewPyramid: 'overviewPyramid.svg',
-            summaryXml: 'summaryXml.xml',
-            debug: true,
-            ignoreDirectories: [
-                'test',
-                'static'
-            ]
-        },
-    },
+        default: {
+            dir: [
+                'php'
+            ],
+            options: {
+                bin: 'vendor/bin/pdepend',
+                jdependChart: 'jdependChart.svg',
+                jdependXml: 'jdependXml.xml',
+                overviewPyramid: 'overviewPyramid.svg',
+                summaryXml: 'summaryXml.xml',
+                coderankMode: 'method',
+                debug: true,
+                ignoreDirectories: [
+                    'ignore'
+                ]
+            }
+        }
+    }
 });
 ```
 


### PR DESCRIPTION
Using the [example on the README](https://github.com/weejames/grunt-pdepend/blob/249718919dd72905926ccaf8894e61e11317a4f9/README.md) results in the following warning:

```
Warning: Cannot read property 'indexOf' of undefined
```

According to the code, `options` and `dir` are required to live inside of specific tasks.
